### PR TITLE
Uninstall script

### DIFF
--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Argentina Regions
  *
@@ -16,7 +15,6 @@ use Magento\Framework\Setup\InstallDataInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 
-
 class InstallData implements InstallDataInterface
 {
 
@@ -28,7 +26,7 @@ class InstallData implements InstallDataInterface
     protected $directoryData;
 
     /**
-     * Init
+     * InstallData constructor.
      *
      * @param Data $directoryData
      */
@@ -37,14 +35,11 @@ class InstallData implements InstallDataInterface
         $this->directoryData = $directoryData;
     }
 
-
     /**
-     * Install Data
+     * Installs data.
      *
-     * @param ModuleDataSetupInterface $setup   Module Data Setup
-     * @param ModuleContextInterface   $context Module Context
-     *
-     * @return void
+     * @param ModuleDataSetupInterface $setup
+     * @param ModuleContextInterface $context
      */
     public function install(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
     {

--- a/Setup/UninstallData.php
+++ b/Setup/UninstallData.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Argentina Regions
+ *
+ * @category   Mugar
+ * @package    Mugar_ArgentinaRegions
+ * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @author     Mugar (https://www.mugar.io/)
+ */
+
+namespace Mugar\ArgentinaRegions\Setup;
+
+use Magento\Framework\Setup\UninstallInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+
+/**
+ * @codeCoverageIgnore
+ */
+class Uninstall implements UninstallInterface
+{
+
+    public function uninstall(SchemaSetupInterface $setup, ModuleContextInterface $context)
+    {
+
+        $setup->startSetup();
+
+        $setup->getConnection()->delete(
+            $setup->getTable('directory_country_region'),
+            ['country_id = ?' => 'AR']
+        );
+
+        $setup->endSetup();
+    }
+
+}

--- a/Setup/UninstallData.php
+++ b/Setup/UninstallData.php
@@ -26,6 +26,11 @@ class Uninstall implements UninstallInterface
         $setup->startSetup();
 
         $setup->getConnection()->delete(
+            $setup->getTable('directory_country_region_name'),
+            ['region_id IN (SELECT region_id FROM directory_country_region WHERE country_id = ?)' => 'AR']
+        );
+
+        $setup->getConnection()->delete(
             $setup->getTable('directory_country_region'),
             ['country_id = ?' => 'AR']
         );


### PR DESCRIPTION
<!---
    Gracias por tu contribución al MugAr.
    Para facilitar el proceso de este pull request recomendamos que agregues la siguiente información: 
     - Descripción del pull request,
     - Issue(s) relacionados a los cambios de código propuestos,
     - Si fuera aplicable, enumerar pasos de test manual para validar la funcionalidad
-->

### Descripción
Se agrega el script de instalación para que se borren los datos insertados en directory_country_region y directory_country_region_name si se usa la desinistalación de Magento.

### Issues relacionados (si fuera aplicable)
1. [https://github.com/holamugar/module-argentinaregions/issues/6](https://github.com/holamugar/module-argentinaregions/issues/6): Script para desinstalación

### Escenarios de testing manual (si fuera aplicable)
1. Una vez instalado el módulo, ejecutar: bin/magento module:uninstall Mugar_ArgentinaRegions
2. En la tabla directory_country_region_name no debe haber ninguna provincia argentina.
3. En la tabla directory_country_region no debe haber ninguna provincia argentina.
