### PR TITLE
Usar import en registration

### DIFF
--- a/registration.php
+++ b/registration.php
@@ -8,8 +8,12 @@
  * @author     Mugar (https://www.mugar.io/)
  */
 
-\Magento\Framework\Component\ComponentRegistrar::register(
-    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+declare(strict_types=1);
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::MODULE,
     'Mugar_ArgentinaRegions',
     __DIR__
 );


### PR DESCRIPTION
### Descripción
Se usar import para mejorar legibilidad del código.

### Issues relacionados (si fuera aplicable)
1. holamugar/module-argentinaregions#14: Usar import en Registration
