### PR TITLE
#16 Se valida que no haya regiones para Argentina

### DIFF
--- a/Setup/Patch/Data/AddRegions.php
+++ b/Setup/Patch/Data/AddRegions.php
@@ -12,12 +12,15 @@ declare(strict_types=1);
 
 namespace Mugar\ArgentinaRegions\Setup\Patch\Data;
 
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchRevertableInterface;
 
 class AddRegions implements DataPatchInterface, PatchRevertableInterface
 {
+    const CONFIG_PATH = 'mugar/argentina-regions/no_installed';
+
     /**
      * ModuleDataSetupInterface
      *
@@ -40,6 +43,30 @@ class AddRegions implements DataPatchInterface, PatchRevertableInterface
     public function apply()
     {
         $this->moduleDataSetup->getConnection()->startSetup();
+
+        $regionCount = $this->moduleDataSetup->getConnection()
+            ->fetchOne(
+                'SELECT COUNT(*) FROM ' . $this->moduleDataSetup->getTable('directory_country_region') . ' WHERE country_id = ?',
+                ['AR']
+            );
+
+        if ($regionCount > 0) {
+            $bind = [
+                'scope' => 'default',
+                'scope_id' => 0,
+                'path' => self::CONFIG_PATH,
+                'value' => '1',
+            ];
+            try {
+                $this->moduleDataSetup->getConnection()->insert(
+                    $this->moduleDataSetup->getTable('core_config_data'),
+                    $bind
+                );
+            } catch (LocalizedException $e) {}
+
+            $this->moduleDataSetup->getConnection()->endSetup();
+            return;
+        }
 
         /**
          * Fill table directory/country_region
@@ -102,6 +129,23 @@ class AddRegions implements DataPatchInterface, PatchRevertableInterface
 
         $tableDirectoryCountryRegionName = $this->moduleDataSetup->getTable('directory_country_region_name');
         $tableDirectoryCountryRegion = $this->moduleDataSetup->getTable('directory_country_region');
+        $tableCoreConfig = $this->moduleDataSetup->getTable('core_config_data');
+
+        $configCount = $this->moduleDataSetup->getConnection()
+            ->fetchOne(
+                'SELECT COUNT(*) FROM ' . $tableCoreConfig . ' WHERE path = ?',
+                [self::CONFIG_PATH]
+            );
+
+        if ($configCount > 0) {
+            $where = ['path = ?' => self::CONFIG_PATH];
+            $this->moduleDataSetup->getConnection()->delete(
+                $tableCoreConfig,
+                $where
+            );
+            $this->moduleDataSetup->getConnection()->endSetup();
+            return;
+        }
 
         $where = [
             'region_id IN (SELECT region_id FROM ' . $tableDirectoryCountryRegion . ' WHERE country_id = ?)' => 'AR'


### PR DESCRIPTION
Se valida la existencia de provincias cargadas previamente para Argentina. En caso de existir, se deja una bandera para que el revert no borre las regiones previamente cargadas por otro modulo.